### PR TITLE
external library import statement

### DIFF
--- a/api/misc.py
+++ b/api/misc.py
@@ -1,4 +1,4 @@
-import envelope
+from envelope import Envelope
 from pydantic import EmailStr
 
 
@@ -29,7 +29,7 @@ Kind regards,
 the automatic API buttler
 """ % (email, hostname, api_key, days_valid, hostname)
 
-    envelope.envelope()\
+    Envelope()\
         .message(body)\
         .subject(subject)\
         .to(email)\


### PR DESCRIPTION
Hello, I've dared to change to interface with Envelope 1.0 -> now the only correct import statement is `from envelope import Envelope` (and I see you are imposing version 1.1). It's slightly longer but I believe more intuitive and conforming naming conventions. Also it does not confuse IDEs' auto complete feature.